### PR TITLE
Config fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# editor specific config folders; not needed or used by devs with other editors
+.vscode/
+.idea/

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>


### PR DESCRIPTION
Hi! I made a few small changes to clean up the repo. Vendor-specific config folders don't need to be part of the repo, since not all developers will use the same editor and those that do may have different preferences for their configurations that could overwrite OP's preferences. Configuration details like this are unrelated to the code's purpose. Given that Go can be edited with anything that can work with text files, we should try to keep what's in the repo specific to the code itself and not be concerned with the dev environment of the respective devs.

I'm trying to do more with Go and this looks like a fun project. I've been learning about TinyGo and I hope to do more with it in the future. Thanks for your work on this project!